### PR TITLE
Added possibility of having typesafe config type inside configview

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
   id 'com.github.hierynomus.license' version '0.14.0'
   id 'com.github.johnrengelman.shadow' version '2.0.1'
   id 'com.github.spotbugs' version '1.6.0'
-  id 'com.github.sherter.google-java-format' version '0.6'
+  id "com.diffplug.gradle.spotless" version "3.25.0"
   id 'net.researchgate.release' version '2.6.0'
   id 'com.bmuschko.nexus' version '2.3.1' apply false
 }
@@ -43,6 +43,12 @@ dependencies {
   compile "com.typesafe:config:${configVersion}"
   testCompile("org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}")
   testRuntime("org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}")
+}
+
+spotless {
+  java {
+    googleJavaFormat("1.7")
+  }
 }
 
 license {

--- a/src/main/java/cz/datadriven/utils/config/view/ConfigViewFactory.java
+++ b/src/main/java/cz/datadriven/utils/config/view/ConfigViewFactory.java
@@ -46,10 +46,10 @@ public class ConfigViewFactory {
   public static <T> T create(Class<T> configViewClass, Config config) {
     if (!ConfigViewProxy.canProxy(configViewClass)) {
       throw new IllegalArgumentException(
-          "Can not instantiate metric group for "
+          "Can not instantiate ConfigView for "
               + "class [ "
               + configViewClass
-              + " ]. Did you forgot @ConfigView annotation?");
+              + " ]. Did you forget @ConfigView annotation?");
     }
     final Enhancer enhancer = new Enhancer();
     enhancer.setCallback(new ConfigViewProxy(new ConfigViewProxy.Factory(config)));

--- a/src/main/java/cz/datadriven/utils/config/view/ConfigViewProxy.java
+++ b/src/main/java/cz/datadriven/utils/config/view/ConfigViewProxy.java
@@ -42,6 +42,7 @@ class ConfigViewProxy implements MethodInterceptor {
           ConfigView.Double.class,
           ConfigView.Duration.class,
           ConfigView.Configuration.class,
+          ConfigView.TypesafeConfig.class,
           ConfigView.Bytes.class,
           ConfigView.Map.class);
 
@@ -81,15 +82,16 @@ class ConfigViewProxy implements MethodInterceptor {
       return ConfigViewFactory.create(claz, config.getConfig(annotation.path()));
     }
 
+    Config createTypeSafeConfig(ConfigView.TypesafeConfig annotation) {
+      return config.getConfig(annotation.path());
+    }
+
     Duration createDuration(ConfigView.Duration annotation) {
       return config.getDuration(annotation.path());
     }
 
     Map<String, Object> createMap(ConfigView.Map annotation) {
-      return config
-          .getConfig(annotation.path())
-          .entrySet()
-          .stream()
+      return config.getConfig(annotation.path()).entrySet().stream()
           .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().unwrapped()));
     }
 
@@ -239,6 +241,12 @@ class ConfigViewProxy implements MethodInterceptor {
         (key, returnType) -> {
           final ConfigView.Configuration annotation = (ConfigView.Configuration) key;
           return factory.createConfig(annotation, returnType);
+        });
+    handlers.put(
+        ConfigView.TypesafeConfig.class,
+        (key, returnType) -> {
+          final ConfigView.TypesafeConfig annotation = (ConfigView.TypesafeConfig) key;
+          return factory.createTypeSafeConfig(annotation);
         });
     handlers.put(
         ConfigView.Bytes.class,

--- a/src/main/java/cz/datadriven/utils/config/view/annotation/ConfigView.java
+++ b/src/main/java/cz/datadriven/utils/config/view/annotation/ConfigView.java
@@ -110,9 +110,23 @@ public @interface ConfigView {
     java.lang.String path();
   }
 
+  /** Handle for obtaining an instance of ConfigView annotated class. */
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
   @interface Configuration {
+
+    /**
+     * The name of the field.
+     *
+     * @return path to the config property
+     */
+    java.lang.String path();
+  }
+
+  /** Handle for obtaining an instance of typesafe Config class. */
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.METHOD)
+  @interface TypesafeConfig {
 
     /**
      * The name of the field.

--- a/src/test/java/cz/datadriven/utils/config/view/GenericConfigTest.java
+++ b/src/test/java/cz/datadriven/utils/config/view/GenericConfigTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 Datadriven.cz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cz.datadriven.utils.config.view;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import cz.datadriven.utils.config.view.annotation.ConfigView;
+import org.junit.jupiter.api.Test;
+
+public class GenericConfigTest {
+
+  @ConfigView
+  interface ShoppingItem {
+    @ConfigView.String(path = "name")
+    String name();
+
+    @ConfigView.Double(path = "price")
+    Double price();
+
+    @ConfigView.TypesafeConfig(path = "properties")
+    Config properties();
+  }
+
+  @ConfigView
+  interface AppleProperties {
+    @ConfigView.String(path = "type")
+    String type();
+
+    @ConfigView.String(path = "color")
+    String color();
+
+    @ConfigView.Integer(path = "category")
+    int category();
+
+    @ConfigView.Boolean(path = "crunchy")
+    boolean isCrunchy();
+
+    @ConfigView.Double(path = "weight")
+    double weight();
+  }
+
+  @ConfigView
+  interface WineProperties {
+    @ConfigView.String(path = "type")
+    String type();
+
+    @ConfigView.String(path = "color")
+    String color();
+
+    @ConfigView.Integer(path = "sweetness")
+    int sweetness();
+
+    @ConfigView.Double(path = "volume")
+    double volume();
+  }
+
+  @Test
+  public void test() {
+    Config listConfig = ConfigFactory.load("generic"); // load nested.conf from resources
+    Double actualPrice = 0.0;
+    for (Config itemConfig : listConfig.getConfigList("shopping-list")) {
+      ShoppingItem item = ConfigViewFactory.create(ShoppingItem.class, itemConfig);
+      actualPrice += item.price();
+      switch (item.name()) {
+        case "apple":
+          {
+            AppleProperties appleProperties =
+                ConfigViewFactory.create(AppleProperties.class, item.properties());
+            assertAppleProps(appleProperties);
+          }
+          break;
+        case "wine":
+          {
+            WineProperties wineProperties =
+                ConfigViewFactory.create(WineProperties.class, item.properties());
+            assertWineProps(wineProperties);
+          }
+          break;
+        default:
+          {
+            throw new IllegalArgumentException("Unknown type of shopping item");
+          }
+      }
+    }
+    assertEquals(13.5, actualPrice, 0.1);
+  }
+
+  private void assertAppleProps(AppleProperties appleProperties) {
+    assertEquals("Red delicious", appleProperties.type());
+    assertEquals("red", appleProperties.color());
+    assertTrue(appleProperties.isCrunchy());
+    assertEquals(1, appleProperties.category());
+    assertEquals(0.33, appleProperties.weight(), 0.1);
+  }
+
+  private void assertWineProps(WineProperties wineProperties) {
+    assertEquals("Chardonnay", wineProperties.type());
+    assertEquals("white", wineProperties.color());
+    assertEquals(2, wineProperties.sweetness());
+    assertEquals(0.7, wineProperties.volume(), 0.1);
+  }
+}

--- a/src/test/resources/generic.conf
+++ b/src/test/resources/generic.conf
@@ -1,0 +1,23 @@
+shopping-list: [
+  {
+    name: "apple"
+    price: 1.0
+    properties {
+      type: "Red delicious"
+      color: "red"
+      category: 1
+      crunchy: true
+      weight: 0.333
+    }
+  },
+  {
+    name: "wine"
+    price: 12.5
+    properties {
+      type: "Chardonnay"
+      color: "white"
+      sweetness: 2
+      volume: 0.7
+    }
+  }
+]


### PR DESCRIPTION
For cases when configview class is not known until runtime. Might be used e.g. for configuration with several I/O types (kafka, remote FS, local FS).

+ example test
+ com.github.sherter.google-java-format changed to com.diffplug.gradle.spotless