### PR TITLE
Typesafe config access feature added

### DIFF
--- a/src/main/java/cz/datadriven/utils/config/view/ConfigViewProxy.java
+++ b/src/main/java/cz/datadriven/utils/config/view/ConfigViewProxy.java
@@ -98,8 +98,11 @@ class ConfigViewProxy implements MethodInterceptor {
     long createBytes(ConfigView.Bytes annotation) {
       return config.getBytes(annotation.path());
     }
-  }
 
+    Config getConfig() {
+      return config;
+    }
+  }
   /**
    * Handler for a specific annotation
    *
@@ -113,8 +116,10 @@ class ConfigViewProxy implements MethodInterceptor {
 
   private final ConcurrentHashMap<String, Object> trackedInstruments = new ConcurrentHashMap<>();
   private final Map<Class<?>, AnnotationHandler<?>> annotationHandlers;
+  private final Factory factory;
 
   ConfigViewProxy(Factory factory) {
+    this.factory = factory;
     this.annotationHandlers = createAnnotationHandlers(factory);
   }
 
@@ -124,6 +129,9 @@ class ConfigViewProxy implements MethodInterceptor {
     final Optional<Annotation> maybeAnnotation = getInstrumentAnnotation(method);
     if (maybeAnnotation.isPresent()) {
       return getOrCreateInstrument(method.getName(), method.getReturnType(), maybeAnnotation.get());
+    } else if (obj instanceof TypesafeConfigProvider
+        && TypesafeConfigProvider.typesafeConfigMethodName().equals(method.getName())) {
+      return factory.getConfig();
     } else {
       return methodProxy.invokeSuper(obj, args);
     }

--- a/src/main/java/cz/datadriven/utils/config/view/ConfigViewProxy.java
+++ b/src/main/java/cz/datadriven/utils/config/view/ConfigViewProxy.java
@@ -129,8 +129,8 @@ class ConfigViewProxy implements MethodInterceptor {
     final Optional<Annotation> maybeAnnotation = getInstrumentAnnotation(method);
     if (maybeAnnotation.isPresent()) {
       return getOrCreateInstrument(method.getName(), method.getReturnType(), maybeAnnotation.get());
-    } else if (obj instanceof TypesafeConfigProvider
-        && TypesafeConfigProvider.typesafeConfigMethodName().equals(method.getName())) {
+    } else if (obj instanceof RawConfigAware
+        && RawConfigAware.rawConfigMethodName().equals(method.getName())) {
       return factory.getConfig();
     } else {
       return methodProxy.invokeSuper(obj, args);

--- a/src/main/java/cz/datadriven/utils/config/view/RawConfigAware.java
+++ b/src/main/java/cz/datadriven/utils/config/view/RawConfigAware.java
@@ -21,15 +21,15 @@ import com.typesafe.config.Config;
  * Enables {@link cz.datadriven.utils.config.view.annotation.ConfigView} annotated interface to
  * provide its underlying {@link Config} if extends this interface.
  */
-public interface TypesafeConfigProvider {
+public interface RawConfigAware {
 
-  static String typesafeConfigMethodName() {
-    return TypesafeConfigProvider.class.getMethods()[0].getName();
+  static String rawConfigMethodName() {
+    return RawConfigAware.class.getMethods()[0].getName();
   }
 
   /**
    * @return underlying {@link Config} of given {@link
    *     cz.datadriven.utils.config.view.annotation.ConfigView} interface
    */
-  Config asTypesafeConfig();
+  Config getRawConfig();
 }

--- a/src/main/java/cz/datadriven/utils/config/view/TypesafeConfigProvider.java
+++ b/src/main/java/cz/datadriven/utils/config/view/TypesafeConfigProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Datadriven.cz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cz.datadriven.utils.config.view;
+
+import com.typesafe.config.Config;
+
+/**
+ * Enables {@link cz.datadriven.utils.config.view.annotation.ConfigView} annotated interface to
+ * provide its underlying {@link Config} if extends this interface.
+ */
+public interface TypesafeConfigProvider {
+
+  static String typesafeConfigMethodName() {
+    return TypesafeConfigProvider.class.getMethods()[0].getName();
+  }
+
+  /**
+   * @return underlying {@link Config} of given {@link
+   *     cz.datadriven.utils.config.view.annotation.ConfigView} interface
+   */
+  Config asTypesafeConfig();
+}

--- a/src/test/java/cz/datadriven/utils/config/view/NestedConfigTest.java
+++ b/src/test/java/cz/datadriven/utils/config/view/NestedConfigTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 public class NestedConfigTest {
 
   @ConfigView
-  interface RootConfig {
+  interface RootConfig extends TypesafeConfigProvider {
     @ConfigView.Integer(path = "cabbage")
     int cabbage();
 
@@ -37,7 +37,7 @@ public class NestedConfigTest {
   }
 
   @ConfigView
-  interface FruitsConfig { // Single nested
+  interface FruitsConfig extends TypesafeConfigProvider { // Single nested
     @ConfigView.Integer(path = "apple")
     int apples();
 
@@ -70,5 +70,14 @@ public class NestedConfigTest {
     assertEquals(ORANGES_COUNT, rootConfig.fruits().citrus().oranges());
     assertEquals(POMELO_COUNT, rootConfig.fruits().citrus().pomelo());
     assertEquals(TOTAL_WEIGHT, rootConfig.totalWeight());
+  }
+
+  @Test
+  public void testRawConfig() {
+    Config config = ConfigFactory.load("nested"); // load nested.conf from resources
+    RootConfig rootConfig = ConfigViewFactory.create(RootConfig.class, config);
+
+    assertEquals(APPLE_COUNT, rootConfig.asTypesafeConfig().getInt("fruit.apple"));
+    assertEquals(APPLE_COUNT, rootConfig.fruits().asTypesafeConfig().getInt("apple"));
   }
 }

--- a/src/test/java/cz/datadriven/utils/config/view/NestedConfigTest.java
+++ b/src/test/java/cz/datadriven/utils/config/view/NestedConfigTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 public class NestedConfigTest {
 
   @ConfigView
-  interface RootConfig extends TypesafeConfigProvider {
+  interface RootConfig extends RawConfigAware {
     @ConfigView.Integer(path = "cabbage")
     int cabbage();
 
@@ -37,7 +37,7 @@ public class NestedConfigTest {
   }
 
   @ConfigView
-  interface FruitsConfig extends TypesafeConfigProvider { // Single nested
+  interface FruitsConfig extends RawConfigAware { // Single nested
     @ConfigView.Integer(path = "apple")
     int apples();
 
@@ -77,7 +77,7 @@ public class NestedConfigTest {
     Config config = ConfigFactory.load("nested"); // load nested.conf from resources
     RootConfig rootConfig = ConfigViewFactory.create(RootConfig.class, config);
 
-    assertEquals(APPLE_COUNT, rootConfig.asTypesafeConfig().getInt("fruit.apple"));
-    assertEquals(APPLE_COUNT, rootConfig.fruits().asTypesafeConfig().getInt("apple"));
+    assertEquals(APPLE_COUNT, rootConfig.getRawConfig().getInt("fruit.apple"));
+    assertEquals(APPLE_COUNT, rootConfig.fruits().getRawConfig().getInt("apple"));
   }
 }


### PR DESCRIPTION
Enables `ConfigView` annotated interface to provide its underlying `Config` if extends `TypesafeConfigProvider` interface.