### PR TITLE
Reusing ConfigView instances when possible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ java {
 def junitJupiterVersion = '5.8.1'
 
 dependencies {
-  api "com.typesafe:config:1.4.1"
-  implementation 'net.bytebuddy:byte-buddy:1.12.1'
+  api "com.typesafe:config:1.4.2"
+  implementation 'net.bytebuddy:byte-buddy:1.12.14'
   testImplementation("org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}")
 }

--- a/src/main/java/cz/datadriven/utils/config/view/ConfigViewFactory.java
+++ b/src/main/java/cz/datadriven/utils/config/view/ConfigViewFactory.java
@@ -18,7 +18,10 @@ package cz.datadriven.utils.config.view;
 import com.typesafe.config.Config;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.ClassFileVersion;
@@ -35,10 +38,39 @@ public class ConfigViewFactory {
     // no-op
   }
 
+  private static class ViewProxyKey<T> {
+    Class<T> viewClass;
+    Config rawConfig;
+
+    public ViewProxyKey(Class<T> configViewClass, Config config) {
+      this.viewClass = configViewClass;
+      this.rawConfig = config;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof ViewProxyKey)) {
+        return false;
+      }
+      ViewProxyKey<?> that = (ViewProxyKey<?>) o;
+      return viewClass.equals(that.viewClass) && rawConfig.equals(that.rawConfig);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(viewClass, rawConfig);
+    }
+  }
+
   private static final Set<TypeDescription> ANNOTATION_TYPE_DESCRIPTORS =
       ConfigViewProxy.ANNOTATIONS.stream()
           .map(TypeDescription.ForLoadedType::of)
           .collect(Collectors.toSet());
+
+  private static final Map<ViewProxyKey<?>, Object> VIEW_PROXY_MAP = new ConcurrentHashMap<>();
 
   /**
    * Create config view from a given config.
@@ -54,7 +86,7 @@ public class ConfigViewFactory {
   }
 
   /**
-   * Create config view from a given config.
+   * Create config view from a given config or return already cached instance.
    *
    * @param configViewClass class to materialize view into
    * @param config config to create view from
@@ -68,14 +100,37 @@ public class ConfigViewFactory {
               "Can not instantiate ConfigView for class [%s]. Did you forget @ConfigView annotation?",
               configViewClass));
     }
+
+    ViewProxyKey<T> proxyKey = new ViewProxyKey<>(configViewClass, config);
+
+    Object proxiedView =
+        VIEW_PROXY_MAP.computeIfAbsent(
+            proxyKey,
+            viewProxyKey -> {
+              final ConfigViewProxy proxy =
+                  new ConfigViewProxy(new ConfigViewProxy.Factory(config));
+              return instantiateView(configViewClass, proxy);
+            });
+
+    return configViewClass.cast(proxiedView);
+  }
+
+  /**
+   * Instatiates given class using provided invocation handler for respective method calls.
+   *
+   * @param configViewClass Class annotated with 'ConfigView' annotation.
+   * @param proxy interceptor for methods providing configuration properties.
+   * @return New instance of given class providing configuration properties by selected methods.
+   * @param <T> Class to instantiate.
+   */
+  private static <T> T instantiateView(Class<T> configViewClass, ConfigViewProxy proxy) {
     try {
       return new ByteBuddy(ClassFileVersion.JAVA_V8)
           .subclass(configViewClass)
           .method(
               ElementMatchers.isAnnotatedWith(ANNOTATION_TYPE_DESCRIPTORS::contains)
                   .or(ElementMatchers.isDeclaredBy(RawConfigAware.class)))
-          .intercept(
-              InvocationHandlerAdapter.of(new ConfigViewProxy(new ConfigViewProxy.Factory(config))))
+          .intercept(InvocationHandlerAdapter.of(proxy))
           .make()
           .load(
               ConfigViewFactory.class.getClassLoader(),

--- a/src/main/java/cz/datadriven/utils/config/view/ConfigViewProxy.java
+++ b/src/main/java/cz/datadriven/utils/config/view/ConfigViewProxy.java
@@ -172,7 +172,6 @@ class ConfigViewProxy implements InvocationHandler, Serializable {
       return factory.getConfig();
     } else {
       throw new UnsupportedOperationException("Not implemented");
-      //      return methodProxy.invokeSuper(obj, args);
     }
   }
 
@@ -200,12 +199,12 @@ class ConfigViewProxy implements InvocationHandler, Serializable {
         Arrays.stream(method.getDeclaredAnnotations())
             .filter(a -> ANNOTATIONS.contains(a.annotationType()))
             .collect(Collectors.toList());
-    if (annotations.size() == 0) {
+    if (annotations.isEmpty()) {
       return Optional.empty();
     } else if (annotations.size() == 1) {
       return Optional.of(annotations.get(0));
     } else {
-      throw new RuntimeException(
+      throw new IllegalArgumentException(
           "Method [ " + method + " ] has more than one instrument annotation.");
     }
   }

--- a/src/test/java/cz/datadriven/utils/config/view/ConfigViewTest.java
+++ b/src/test/java/cz/datadriven/utils/config/view/ConfigViewTest.java
@@ -167,9 +167,7 @@ class ConfigViewTest {
     final Config config = ConfigFactory.empty();
     assertThrows(
         IllegalArgumentException.class,
-        () -> {
-          ConfigViewFactory.create(NonAnnotatedTestConfigView.class, config);
-        });
+        () -> ConfigViewFactory.create(NonAnnotatedTestConfigView.class, config));
   }
 
   @Test
@@ -193,5 +191,17 @@ class ConfigViewTest {
     Assertions.assertEquals(10, mapConfig.data().get("regular-apple"));
     Assertions.assertEquals(20, mapConfig.data().get("quoted-apple"));
     Assertions.assertEquals(30, mapConfig.data().get("dotted.apple"));
+  }
+
+  @Test
+  void sameClassTest() {
+    final Config config =
+        ConfigFactory.empty()
+            .withValue("first", ConfigValueFactory.fromAnyRef("first_value"))
+            .withValue("second", ConfigValueFactory.fromAnyRef("second_value"));
+    final TestConfigView wrap = ConfigViewFactory.create(TestConfigView.class, config);
+    final TestConfigView anotherWrap = ConfigViewFactory.create(TestConfigView.class, config);
+    assertEquals(wrap.getClass(), anotherWrap.getClass());
+    assertEquals(wrap, anotherWrap);
   }
 }


### PR DESCRIPTION
Every time a class gets instantiated by ByteBuddy, new Class is created, then single instace is created using that class and this particular class is never used again. Such behavior can be seen in test and verified easily, e.g. by debugging in IDE.

![Screenshot from 2022-08-29 10-56-42](https://user-images.githubusercontent.com/6716429/187212368-05845067-625f-4713-a55d-198813839196.png)

In some cases this approach leads to many classes being spawned and in extreme cases leads to an app using ConfigView crashing once its metaspace is full.

Also bytebuddy updated to include latest bugfixes: https://github.com/raphw/byte-buddy/releases